### PR TITLE
Broadcast events instantly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: php
+
 php:
   - '7.3'
   - '7.4'
   - '8.0'
+
+install:
+  - composer install
+
+script: phpunit

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "friendsofcat/bulk-actions",
     "description": "Bulk action support for Laravel applications.",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "type": "library",
     "readme": "README.md",
     "license": "MIT",

--- a/src/Events/JobEvent.php
+++ b/src/Events/JobEvent.php
@@ -5,11 +5,11 @@ namespace FriendsOfCat\BulkActions\Events;
 use FriendsOfCat\BulkActions\Models\Job;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-abstract class JobEvent implements ShouldBroadcast
+abstract class JobEvent implements ShouldBroadcastNow
 {
     use Dispatchable;
     use InteractsWithSockets;

--- a/tests/BulkActionsTest.php
+++ b/tests/BulkActionsTest.php
@@ -2,17 +2,16 @@
 
 namespace FriendsOfCat\BulkActions\Tests;
 
-use FriendsOfCat\BulkActions\BulkActionsServiceProvider;
 use FriendsOfCat\BulkActions\Dispatcher;
 use FriendsOfCat\BulkActions\Tests\Stubs\TestAction;
 use FriendsOfCat\BulkActions\Tests\Stubs\TestActionNoExecuteMethod;
 use FriendsOfCat\BulkActions\Tests\Stubs\User;
+use FriendsOfCat\BulkActions\Tests\TestCase;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Queue;
-use Orchestra\Testbench\TestCase;
 use RuntimeException;
 
 class BulkActionsTest extends TestCase
@@ -69,13 +68,6 @@ class BulkActionsTest extends TestCase
         $this->dispatcher->dispatch(TestActionNoExecuteMethod::class, $models);
 
         Queue::assertNothingPushed();
-    }
-
-    protected function getPackageProviders($app)
-    {
-        return [
-            BulkActionsServiceProvider::class,
-        ];
     }
 
     protected function createUser(): User

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace FriendsOfCat\BulkActions\Tests;
+
+use FriendsOfCat\BulkActions\BulkActionsServiceProvider;
+use Orchestra\Testbench\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            BulkActionsServiceProvider::class,
+        ];
+    }
+}


### PR DESCRIPTION
Uses `ShouldBroadcastNow` instead of `ShouldBroadcast`. This broadcasts the notification instantly after a single job finishes instead of pushing the broadcast to the queue, as that meant the notifications were only dispatched after _all_ jobs had finished.